### PR TITLE
refactor: add resize observer and controls for switching table view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@zero-tech/zapp-utils": "^0.6.0",
 				"@zero-tech/zfi-sdk": "0.2.1",
 				"@zero-tech/zns-sdk": "0.6.1",
-				"@zero-tech/zui": "^0.18.1",
+				"@zero-tech/zui": "^0.18.3",
 				"classnames": "^2.3.1",
 				"lodash": "^4.17.21",
 				"millify": "^5.0.1",
@@ -6677,9 +6677,10 @@
 			}
 		},
 		"node_modules/@zero-tech/zui": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.18.1.tgz",
-			"integrity": "sha512-xjSWjYinjdCxJ6iPuxPdQvcUldFqiy2y7ThiMiiLyc6uOQx2S+hOvm5Q574kDvDaOv7vIZkOlbe5BFzNhzZx5Q==",
+			"version": "0.18.3",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.18.3.tgz",
+			"integrity": "sha512-VXWPnQfM4aC75aiHA3WzzdsP01mYkVYmxLIXlEd8s4UlDETHyJ+3Mbf85CVElfk811iQj986Z8Qw8Aqt4CDCgA==",
+			"license": "ISC",
 			"dependencies": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",
 				"@radix-ui/react-accordion": "^1.0.1",
@@ -23664,9 +23665,9 @@
 			}
 		},
 		"@zero-tech/zui": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.18.1.tgz",
-			"integrity": "sha512-xjSWjYinjdCxJ6iPuxPdQvcUldFqiy2y7ThiMiiLyc6uOQx2S+hOvm5Q574kDvDaOv7vIZkOlbe5BFzNhzZx5Q==",
+			"version": "0.18.3",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zui/-/zui-0.18.3.tgz",
+			"integrity": "sha512-VXWPnQfM4aC75aiHA3WzzdsP01mYkVYmxLIXlEd8s4UlDETHyJ+3Mbf85CVElfk811iQj986Z8Qw8Aqt4CDCgA==",
 			"requires": {
 				"@radix-ui/react-accessible-icon": "^1.0.0",
 				"@radix-ui/react-accordion": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"@zero-tech/zapp-utils": "^0.6.0",
 		"@zero-tech/zfi-sdk": "0.2.1",
 		"@zero-tech/zns-sdk": "0.6.1",
-		"@zero-tech/zui": "^0.18.1",
+		"@zero-tech/zui": "^0.18.3",
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",
 		"millify": "^5.0.1",

--- a/src/features/my-deposits/DepositsTable.module.scss
+++ b/src/features/my-deposits/DepositsTable.module.scss
@@ -1,14 +1,5 @@
 @import '../../styles/breakpoints';
 
-.Toggle {
-	display: none;
-
-	// @note: this has to match GRID_WIDTH_TOGGLE in DepositsTable.tsx
-	@include container-breakpoint(600) {
-		display: flex;
-	}
-}
-
 .DepositsView {
 	display: flex;
 	flex-direction: column;

--- a/src/features/my-deposits/DepositsTable.module.scss
+++ b/src/features/my-deposits/DepositsTable.module.scss
@@ -1,5 +1,14 @@
 @import '../../styles/breakpoints';
 
+.Toggle {
+	display: none;
+
+	// @note: this has to match GRID_WIDTH_TOGGLE in DepositsTable.tsx
+	@include container-breakpoint(600) {
+		display: flex;
+	}
+}
+
 .DepositsView {
 	display: flex;
 	flex-direction: column;
@@ -8,19 +17,5 @@
 
 	.Grid {
 		grid-template-columns: 1fr;
-	}
-
-	.Table {
-		display: none;
-	}
-
-	@include container-breakpoint(500) {
-		.Grid {
-			display: none;
-		}
-
-		.Table {
-			display: contents;
-		}
 	}
 }

--- a/src/features/my-deposits/DepositsTable.tsx
+++ b/src/features/my-deposits/DepositsTable.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { COLUMNS } from './Deposits.helpers';
@@ -6,17 +6,23 @@ import { ROUTE_NAMES, ROUTES } from '../../lib/constants/routes';
 import { useAllDeposits, DepositData } from '../../lib/hooks/useAllDeposits';
 
 import { DepositRow } from './DepositRow';
+import { DepositCard } from './DepositCard';
 
 import {
 	Body,
+	Controls,
 	Grid,
 	Header,
 	HeaderGroup,
 	Table,
+	View,
+	ViewToggle,
 } from '@zero-tech/zui/components/Table';
 
 import styles from './DepositsTable.module.scss';
-import { DepositCard } from './DepositCard';
+
+// @note: this value is being used in DepositsTable.module.scss - change in both places
+const GRID_WIDTH_TOGGLE = 600;
 
 export interface DepositsTableProps {
 	/*
@@ -27,13 +33,32 @@ export interface DepositsTableProps {
 }
 
 export const DepositsTable: FC<DepositsTableProps> = ({ account }) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [view, setView] = useState<View>(View.TABLE);
+
 	const { data: queryData, isLoading } = useAllDeposits({ account });
 
+	useEffect(() => {
+		const resizeObserver = new ResizeObserver(() => {
+			if (containerRef.current) {
+				if (containerRef.current.offsetWidth <= GRID_WIDTH_TOGGLE) {
+					setView(View.GRID);
+				}
+			}
+		});
+		resizeObserver.observe(containerRef.current);
+		return () => resizeObserver.disconnect();
+	}, [containerRef]);
+
 	return (
-		<DepositsView
-			depositsCollection={queryData?.deposits}
-			isLoading={isLoading}
-		/>
+		<div ref={containerRef}>
+			<DepositsTableControls view={view} onChangeView={setView} />
+			<DepositsView
+				depositsCollection={queryData?.deposits}
+				isLoading={isLoading}
+				isGridView={view === View.GRID}
+			/>
+		</div>
 	);
 };
 
@@ -43,37 +68,48 @@ export const DepositsTable: FC<DepositsTableProps> = ({ account }) => {
 interface DepositsViewProps {
 	depositsCollection: DepositData[];
 	isLoading: boolean;
+	isGridView: boolean;
 }
 
-const DepositsView = ({ depositsCollection, isLoading }: DepositsViewProps) => {
+const DepositsView = ({
+	depositsCollection,
+	isLoading,
+	isGridView,
+}: DepositsViewProps) => {
 	//  If loading, or there are already deposits loaded, render the table
 	if (isLoading || Boolean(depositsCollection?.length)) {
-		return (
-			<div className={styles.DepositsView}>
-				<Grid className={styles.Grid}>
-					{depositsCollection?.map((deposit) => (
-						<DepositCard deposit={deposit} isLoading={isLoading} />
-					))}
-				</Grid>
-
-				<div className={styles.Table}>
-					<Table>
-						<HeaderGroup>
-							{COLUMNS.map((column) => (
-								<Header key={column.id} alignment={column.alignment}>
-									{column.header}
-								</Header>
-							))}
-						</HeaderGroup>
-						<Body>
-							{depositsCollection?.map((deposit) => (
-								<DepositRow deposit={deposit} />
-							))}
-						</Body>
-					</Table>
+		if (isGridView) {
+			return (
+				<div className={styles.DepositsView}>
+					<Grid className={styles.Grid}>
+						{depositsCollection?.map((deposit) => (
+							<DepositCard deposit={deposit} isLoading={isLoading} />
+						))}
+					</Grid>
 				</div>
-			</div>
-		);
+			);
+		} else {
+			return (
+				<div className={styles.DepositsView}>
+					<div className={styles.Table}>
+						<Table>
+							<HeaderGroup>
+								{COLUMNS.map((column) => (
+									<Header key={column.id} alignment={column.alignment}>
+										{column.header}
+									</Header>
+								))}
+							</HeaderGroup>
+							<Body>
+								{depositsCollection?.map((deposit) => (
+									<DepositRow deposit={deposit} />
+								))}
+							</Body>
+						</Table>
+					</div>
+				</div>
+			);
+		}
 	}
 
 	// If loaded, and there are no deposits, render a message
@@ -105,4 +141,28 @@ interface MessageProps {
 
 const Message = ({ children }: MessageProps) => {
 	return <p className={styles.Empty}>{children}</p>;
+};
+
+/**********************
+ * Controls
+ *********************/
+
+interface DepositsTableControlsProps {
+	view: View;
+	onChangeView: (view: View) => void;
+}
+
+const DepositsTableControls = ({
+	view,
+	onChangeView,
+}: DepositsTableControlsProps): JSX.Element => {
+	return (
+		<Controls>
+			<ViewToggle
+				className={styles.Toggle}
+				view={view}
+				onChange={onChangeView}
+			/>
+		</Controls>
+	);
 };

--- a/src/features/my-deposits/DepositsTable.tsx
+++ b/src/features/my-deposits/DepositsTable.tsx
@@ -7,21 +7,20 @@ import { useAllDeposits, DepositData } from '../../lib/hooks/useAllDeposits';
 
 import { DepositRow } from './DepositRow';
 import { DepositCard } from './DepositCard';
+import { TableControls } from '../ui/TableControls';
 
 import {
 	Body,
-	Controls,
 	Grid,
 	Header,
 	HeaderGroup,
 	Table,
 	View,
-	ViewToggle,
 } from '@zero-tech/zui/components/Table';
 
 import styles from './DepositsTable.module.scss';
 
-// @note: this value is being used in DepositsTable.module.scss - change in both places
+// @note: this value is being used in TableControls.module.scss - change in both places
 const GRID_WIDTH_TOGGLE = 600;
 
 export interface DepositsTableProps {
@@ -52,7 +51,7 @@ export const DepositsTable: FC<DepositsTableProps> = ({ account }) => {
 
 	return (
 		<div ref={containerRef}>
-			<DepositsTableControls view={view} onChangeView={setView} />
+			<TableControls view={view} onChangeView={setView} />
 			<DepositsView
 				depositsCollection={queryData?.deposits}
 				isLoading={isLoading}
@@ -141,28 +140,4 @@ interface MessageProps {
 
 const Message = ({ children }: MessageProps) => {
 	return <p className={styles.Empty}>{children}</p>;
-};
-
-/**********************
- * Controls
- *********************/
-
-interface DepositsTableControlsProps {
-	view: View;
-	onChangeView: (view: View) => void;
-}
-
-const DepositsTableControls = ({
-	view,
-	onChangeView,
-}: DepositsTableControlsProps): JSX.Element => {
-	return (
-		<Controls>
-			<ViewToggle
-				className={styles.Toggle}
-				view={view}
-				onChange={onChangeView}
-			/>
-		</Controls>
-	);
 };

--- a/src/features/ui/TableControls/TableControls.module.scss
+++ b/src/features/ui/TableControls/TableControls.module.scss
@@ -1,0 +1,10 @@
+@import '../../../styles/breakpoints';
+
+.Toggle {
+	display: none;
+
+	// @note: this has to match GRID_WIDTH_TOGGLE in PoolTable.tsx and DepositsTable.tsx
+	@include container-breakpoint(600) {
+		display: flex;
+	}
+}

--- a/src/features/ui/TableControls/TableControls.tsx
+++ b/src/features/ui/TableControls/TableControls.tsx
@@ -1,0 +1,23 @@
+import styles from './TableControls.module.scss';
+
+import { Controls, View, ViewToggle } from '@zero-tech/zui/components';
+
+interface TableControlsProps {
+	view: View;
+	onChangeView: (view: View) => void;
+}
+
+export const TableControls = ({
+	view,
+	onChangeView,
+}: TableControlsProps): JSX.Element => {
+	return (
+		<Controls>
+			<ViewToggle
+				className={styles.Toggle}
+				view={view}
+				onChange={onChangeView}
+			/>
+		</Controls>
+	);
+};

--- a/src/features/ui/TableControls/index.ts
+++ b/src/features/ui/TableControls/index.ts
@@ -1,0 +1,1 @@
+export * from './TableControls';

--- a/src/features/view-pools/PoolCard.module.scss
+++ b/src/features/view-pools/PoolCard.module.scss
@@ -37,7 +37,7 @@
 	.TextButton {
 		display: flex;
 		align-items: center;
-		justify-content: end;
+		justify-content: flex-end;
 		gap: 0.35rem;
 		cursor: pointer;
 

--- a/src/features/view-pools/PoolTable.module.scss
+++ b/src/features/view-pools/PoolTable.module.scss
@@ -1,5 +1,14 @@
 @import '../../styles/breakpoints';
 
+.Toggle {
+	display: none;
+
+	// @note: this has to match GRID_WIDTH_TOGGLE in SubdomainTable.tsx
+	@include container-breakpoint(600) {
+		display: flex;
+	}
+}
+
 .PoolView {
 	display: flex;
 	flex-direction: column;
@@ -8,19 +17,5 @@
 
 	.Grid {
 		grid-template-columns: 1fr;
-	}
-
-	.Table {
-		display: none;
-	}
-
-	@include container-breakpoint(500) {
-		.Grid {
-			display: none;
-		}
-
-		.Table {
-			display: contents;
-		}
 	}
 }

--- a/src/features/view-pools/PoolTable.module.scss
+++ b/src/features/view-pools/PoolTable.module.scss
@@ -3,7 +3,7 @@
 .Toggle {
 	display: none;
 
-	// @note: this has to match GRID_WIDTH_TOGGLE in SubdomainTable.tsx
+	// @note: this has to match GRID_WIDTH_TOGGLE in PoolTable.tsx
 	@include container-breakpoint(600) {
 		display: flex;
 	}

--- a/src/features/view-pools/PoolTable.module.scss
+++ b/src/features/view-pools/PoolTable.module.scss
@@ -1,14 +1,5 @@
 @import '../../styles/breakpoints';
 
-.Toggle {
-	display: none;
-
-	// @note: this has to match GRID_WIDTH_TOGGLE in PoolTable.tsx
-	@include container-breakpoint(600) {
-		display: flex;
-	}
-}
-
 .PoolView {
 	display: flex;
 	flex-direction: column;

--- a/src/features/view-pools/PoolTable.tsx
+++ b/src/features/view-pools/PoolTable.tsx
@@ -45,7 +45,7 @@ const PoolView = ({ poolAddressCollection }: PoolViewProps) => {
 		<div className={styles.PoolView}>
 			<Grid className={styles.Grid}>
 				{poolAddressCollection?.map((poolAddress) => (
-					<PoolCard poolAddress={poolAddress} />
+					<PoolCard key={`pool-${poolAddress}`} poolAddress={poolAddress} />
 				))}
 			</Grid>
 
@@ -60,7 +60,7 @@ const PoolView = ({ poolAddressCollection }: PoolViewProps) => {
 					</HeaderGroup>
 					<Body>
 						{poolAddressCollection?.map((poolAddress) => (
-							<PoolRow poolAddress={poolAddress} />
+							<PoolRow key={`pool-${poolAddress}`} poolAddress={poolAddress} />
 						))}
 					</Body>
 				</Table>

--- a/src/features/view-pools/PoolTable.tsx
+++ b/src/features/view-pools/PoolTable.tsx
@@ -5,20 +5,19 @@ import { usePools } from '../../lib/hooks/usePools';
 
 import { PoolRow } from './PoolRow';
 import { PoolCard } from './PoolCard';
+import { TableControls } from '../ui/TableControls';
 import {
 	Body,
-	Controls,
 	Grid,
 	Header,
 	HeaderGroup,
 	Table,
 	View,
-	ViewToggle,
 } from '@zero-tech/zui/components/Table';
 
 import styles from './PoolTable.module.scss';
 
-// @note: this value is being used in PoolTable.module.scss - change in both places
+// @note: this value is being used in TableControls.module.scss - change in both places
 const GRID_WIDTH_TOGGLE = 600;
 
 export const PoolTable: FC = () => {
@@ -41,7 +40,7 @@ export const PoolTable: FC = () => {
 
 	return (
 		<div ref={containerRef}>
-			<PoolTableControls view={view} onChangeView={setView} />
+			<TableControls view={view} onChangeView={setView} />
 			<PoolView
 				isGridView={view === View.GRID}
 				poolAddressCollection={tableData.map(
@@ -99,28 +98,4 @@ const PoolView = ({ isGridView, poolAddressCollection }: PoolViewProps) => {
 			</div>
 		);
 	}
-};
-
-/**********************
- * Controls
- *********************/
-
-interface PoolTableControlsProps {
-	view: View;
-	onChangeView: (view: View) => void;
-}
-
-const PoolTableControls = ({
-	view,
-	onChangeView,
-}: PoolTableControlsProps): JSX.Element => {
-	return (
-		<Controls>
-			<ViewToggle
-				className={styles.Toggle}
-				view={view}
-				onChange={onChangeView}
-			/>
-		</Controls>
-	);
 };

--- a/src/features/view-pools/PoolTable.tsx
+++ b/src/features/view-pools/PoolTable.tsx
@@ -18,7 +18,7 @@ import {
 
 import styles from './PoolTable.module.scss';
 
-// @note: this value is being used in SubdomainTable.module.scss - change in both places
+// @note: this value is being used in PoolTable.module.scss - change in both places
 const GRID_WIDTH_TOGGLE = 600;
 
 export const PoolTable: FC = () => {

--- a/src/features/view-pools/PoolTable.tsx
+++ b/src/features/view-pools/PoolTable.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 
 import { COLUMNS } from './Pools.helpers';
 import { usePools } from '../../lib/hooks/usePools';
@@ -7,25 +7,48 @@ import { PoolRow } from './PoolRow';
 import { PoolCard } from './PoolCard';
 import {
 	Body,
+	Controls,
 	Grid,
 	Header,
 	HeaderGroup,
 	Table,
+	View,
+	ViewToggle,
 } from '@zero-tech/zui/components/Table';
 
 import styles from './PoolTable.module.scss';
 
-export const PoolTable: FC = () => {
-	const { wildPool, liquidityPool } = usePools();
+// @note: this value is being used in SubdomainTable.module.scss - change in both places
+const GRID_WIDTH_TOGGLE = 600;
 
+export const PoolTable: FC = () => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const { wildPool, liquidityPool } = usePools();
 	const tableData = [wildPool, liquidityPool];
+	const [view, setView] = useState<View>(View.TABLE);
+
+	useEffect(() => {
+		const resizeObserver = new ResizeObserver(() => {
+			if (containerRef.current) {
+				if (containerRef.current.offsetWidth <= GRID_WIDTH_TOGGLE) {
+					setView(View.GRID);
+				}
+			}
+		});
+		resizeObserver.observe(containerRef.current);
+		return () => resizeObserver.disconnect();
+	}, [containerRef]);
 
 	return (
-		<PoolView
-			poolAddressCollection={tableData.map(
-				(poolAddressCollection) => poolAddressCollection.address,
-			)}
-		/>
+		<div ref={containerRef}>
+			<PoolTableControls view={view} onChangeView={setView} />
+			<PoolView
+				isGridView={view === View.GRID}
+				poolAddressCollection={tableData.map(
+					(poolAddressCollection) => poolAddressCollection.address,
+				)}
+			/>
+		</div>
 	);
 };
 
@@ -33,38 +56,71 @@ export const PoolTable: FC = () => {
  * PoolView Row/Card  *
  *********************/
 interface PoolViewProps {
+	isGridView: boolean;
 	poolAddressCollection: string[];
 }
 
-const PoolView = ({ poolAddressCollection }: PoolViewProps) => {
+const PoolView = ({ isGridView, poolAddressCollection }: PoolViewProps) => {
 	if (poolAddressCollection.length === 0) {
 		return <></>;
 	}
-
-	return (
-		<div className={styles.PoolView}>
-			<Grid className={styles.Grid}>
-				{poolAddressCollection?.map((poolAddress) => (
-					<PoolCard key={`pool-${poolAddress}`} poolAddress={poolAddress} />
-				))}
-			</Grid>
-
-			<div className={styles.Table}>
-				<Table>
-					<HeaderGroup>
-						{COLUMNS.map((column) => (
-							<Header key={column.id} alignment={column.alignment}>
-								{column.header}
-							</Header>
-						))}
-					</HeaderGroup>
-					<Body>
-						{poolAddressCollection?.map((poolAddress) => (
-							<PoolRow key={`pool-${poolAddress}`} poolAddress={poolAddress} />
-						))}
-					</Body>
-				</Table>
+	if (isGridView) {
+		return (
+			<div className={styles.PoolView}>
+				<Grid className={styles.Grid}>
+					{poolAddressCollection?.map((poolAddress) => (
+						<PoolCard key={`pool-${poolAddress}`} poolAddress={poolAddress} />
+					))}
+				</Grid>
 			</div>
-		</div>
+		);
+	} else {
+		return (
+			<div className={styles.PoolView}>
+				<div className={styles.Table}>
+					<Table>
+						<HeaderGroup>
+							{COLUMNS.map((column) => (
+								<Header key={column.id} alignment={column.alignment}>
+									{column.header}
+								</Header>
+							))}
+						</HeaderGroup>
+						<Body>
+							{poolAddressCollection?.map((poolAddress) => (
+								<PoolRow
+									key={`pool-${poolAddress}`}
+									poolAddress={poolAddress}
+								/>
+							))}
+						</Body>
+					</Table>
+				</div>
+			</div>
+		);
+	}
+};
+
+/**********************
+ * Controls
+ *********************/
+
+interface PoolTableControlsProps {
+	view: View;
+	onChangeView: (view: View) => void;
+}
+
+const PoolTableControls = ({
+	view,
+	onChangeView,
+}: PoolTableControlsProps): JSX.Element => {
+	return (
+		<Controls>
+			<ViewToggle
+				className={styles.Toggle}
+				view={view}
+				onChange={onChangeView}
+			/>
+		</Controls>
 	);
 };

--- a/src/pages/Deposits.module.scss
+++ b/src/pages/Deposits.module.scss
@@ -1,4 +1,10 @@
 .ConnectWalletWrapper {
 	display: flex;
 	justify-content: center;
+
+	div {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
 }

--- a/src/pages/Deposits.module.scss
+++ b/src/pages/Deposits.module.scss
@@ -1,10 +1,4 @@
 .ConnectWalletWrapper {
 	display: flex;
 	justify-content: center;
-
-	div {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-	}
 }


### PR DESCRIPTION

## 1. PR type
- Feature
- Refactoring (no functional changes, no api changes)
 
## 2. What is the old behaviour?
Using CSS to hide/display table view and grid view.

## 3. What is the new behaviour?
- use resize observer to switch table view and grid view with breakpoints
- add grid view and table view controls