### PR TITLE
fix: style touch ups

### DIFF
--- a/src/features/my-deposits/DepositsTable.module.scss
+++ b/src/features/my-deposits/DepositsTable.module.scss
@@ -13,4 +13,13 @@
 			grid-template-columns: 1fr;
 		}
 	}
+
+	.Empty {
+		padding: 1rem;
+		text-align: center;
+
+		a {
+			color: var(--color-secondary-11);
+		}
+	}
 }

--- a/src/features/my-deposits/DepositsTable.tsx
+++ b/src/features/my-deposits/DepositsTable.tsx
@@ -123,6 +123,7 @@ const DepositsView = ({
 				>
 					Pools Page
 				</Link>
+				.
 			</Message>
 		);
 	}

--- a/src/features/ui/PoolDetail/PoolDetail.module.scss
+++ b/src/features/ui/PoolDetail/PoolDetail.module.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	align-items: center;
 	gap: 1rem;
-	padding: 1rem;
+	padding: 1rem 1rem 1rem 0;
 
 	.Thumbnail {
 		height: 2.5rem;


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://wilderworld.atlassian.net/jira/software/c/projects/ZAP/boards/34?modal=detail&selectedIssue=ZAP-172)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- fix

## 3. What is the old behaviour?
Pool row padding is not aligned with table headers.
Empty states have incorrect styles and positioning. Should be positioned in the centre and links should be clear as clickable.

## 4. What is the new behaviour?
Styles and empty state fixed.

<img width="1440" alt="Screenshot 2023-05-03 at 10 53 48" src="https://user-images.githubusercontent.com/39112648/235815468-fb873b54-f881-486d-9bb1-a55538174e33.png">

<img width="1440" alt="Screenshot 2023-05-03 at 10 52 58" src="https://user-images.githubusercontent.com/39112648/235815480-82209775-5718-44ae-b9eb-63a8a8cb9f67.png">

<img width="1440" alt="Screenshot 2023-05-03 at 11 01 21" src="https://user-images.githubusercontent.com/39112648/235815521-c5caa1e8-260c-49e6-88dc-0cfdc265e1d5.png">
